### PR TITLE
Bump: Update React-schedular@2.7.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "portfolio",
       "dependencies": {
-        "@aldabil/react-scheduler": "2.6.4",
+        "@aldabil/react-scheduler": "^2.7.20",
         "@emotion/react": "^11.10.6",
         "@emotion/server": "^11.10.0",
         "@emotion/styled": "^11.10.6",
@@ -48,13 +48,13 @@
       }
     },
     "node_modules/@aldabil/react-scheduler": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@aldabil/react-scheduler/-/react-scheduler-2.6.4.tgz",
-      "integrity": "sha512-yB2pRa9YwVcP2LRvvJsLG282gH/YDCTUWSl48gPbhE1NJ4aRfx6AxYbb7Oce0TVRVllJ2j6GXrdm+oCgtUzr3A==",
+      "version": "2.7.20",
+      "resolved": "https://registry.npmjs.org/@aldabil/react-scheduler/-/react-scheduler-2.7.20.tgz",
+      "integrity": "sha512-Msfa8Om1zVoH/63Sy/RJ8YwqKNGjp4IM31WKDaPyUtEvps9TTwbMpTQ1BPEvRuAX9t3CGMn4/owfU3Kn8p5/xQ==",
       "peerDependencies": {
         "@mui/icons-material": ">=5.0.0",
         "@mui/material": ">=5.0.0",
-        "@mui/x-date-pickers": ">=5.0.0-alpha",
+        "@mui/x-date-pickers": ">=6.0.0-alpha",
         "date-fns": ">=2.2",
         "react": ">=17.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "npm run check-types && next lint"
   },
   "dependencies": {
-    "@aldabil/react-scheduler": "2.6.4",
+    "@aldabil/react-scheduler": "^2.7.20",
     "@emotion/react": "^11.10.6",
     "@emotion/server": "^11.10.0",
     "@emotion/styled": "^11.10.6",

--- a/pages/contents/kosen-calendar.tsx
+++ b/pages/contents/kosen-calendar.tsx
@@ -91,7 +91,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
   // console.log(events);
   return {
     props: { resources, events },
-    revalidate: 60 * 60,
+    revalidate: 60,
   };
 };
 
@@ -114,19 +114,7 @@ const Page: NextPage<Props> = ({ resources, events: eventsRaw }) => {
     return eventsRaw.flatMap((data, i) => {
       const start = new Date(data.start);
       const end = new Date(data.end);
-      if (start.getTime() >= end.getTime()) {
-        console.log("invalid", data);
-        return [];
-      }
-      return [
-        {
-          event_id: i,
-          title: data.title,
-          start: new Date(data.start),
-          end: new Date(data.end),
-          name: data.name,
-        },
-      ];
+      return [{ event_id: i, title: data.title, start, end, name: data.name }];
     });
   }, [eventsRaw]);
 
@@ -235,13 +223,13 @@ const Page: NextPage<Props> = ({ resources, events: eventsRaw }) => {
               weekStartOn: 1,
               startHour: 0,
               endHour: 23,
-              step: 120,
+              step: 240,
               cellRenderer: () => <></>,
             }}
             day={{
               startHour: 0,
               endHour: 23,
-              step: 120,
+              step: 240,
               cellRenderer: () => <></>,
             }}
             editable={false}

--- a/pages/contents/kosen-calendar.tsx
+++ b/pages/contents/kosen-calendar.tsx
@@ -203,6 +203,7 @@ const Page: NextPage<Props> = ({ resources, events: eventsRaw }) => {
           <Scheduler
             events={events}
             locale={ja}
+            timeZone="Asia/Tokyo"
             view="month"
             resourceViewMode="tabs"
             resources={resources}


### PR DESCRIPTION
React-schedularのパフォーマンスが改善されていたのを確認したためアップデート
ただし、date-viewの切り替え（日表示、週表示等）の切り替えは遅い。このviewは使用しないため許容した。

また、revalidate時間を60秒に変更。icalの変更がより即座に反映されるようになった。