### PR TITLE
👍 react-twitter-widgets 依存を削除

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "react-dom": "18.3.1",
         "react-icons": "^5.5.0",
         "react-leaflet": "^4.2.1",
-        "react-twitter-widgets": "^1.11.0",
         "react-youtube": "^10.1.0",
         "recharts": "^3.1.2",
         "sharp": "^0.34.3",
@@ -9006,11 +9005,6 @@
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
       "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
     },
-    "node_modules/loadjs": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loadjs/-/loadjs-4.3.0.tgz",
-      "integrity": "sha512-vNX4ZZLJBeDEOBvdr2v/F+0aN5oMuPu7JTqrMwp+DtgK+AryOlpy6Xtm2/HpNr+azEa828oQjOtWsB6iDtSfSQ=="
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -10149,17 +10143,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/react-twitter-widgets": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/react-twitter-widgets/-/react-twitter-widgets-1.11.0.tgz",
-      "integrity": "sha512-PMCLJQc30iqy01y1b2+HnMfCX+ZkOxWaPKJb4BhHgOgjSjoZb68K5T0nq3q+3YbX9K7OH0bhptgDihtBG/BqRQ==",
-      "dependencies": {
-        "loadjs": "^4.2.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-youtube": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "react-dom": "18.3.1",
     "react-icons": "^5.5.0",
     "react-leaflet": "^4.2.1",
-    "react-twitter-widgets": "^1.11.0",
     "react-youtube": "^10.1.0",
     "recharts": "^3.1.2",
     "sharp": "^0.34.3",

--- a/pages/sztm-bot.tsx
+++ b/pages/sztm-bot.tsx
@@ -1,6 +1,6 @@
 import { NextPage, GetStaticProps } from "next";
+import Script from "next/script";
 import { Typography, Box } from "@mui/material";
-import { Mention, Tweet } from "react-twitter-widgets";
 
 import Link from "../src/link";
 import Title from "../components/title";
@@ -23,33 +23,9 @@ const Page: NextPage<Props> = ({ botWorking }) => {
         <Box sx={{ my: 1 }}>{botWorking ? `Bot稼働中` : "Bot停止中"}</Box>
         <Box sx={{ my: 1, textAlign: "center", width: "90%" }}>
           すずともが制作しているBot達です。可愛がってあげてください。
-          <br />
-          以前のサーバでいろいろ動かしていましたが、サーバPCが壊れてしまったので再構築していますので、まだ未整備のBOTはしばしお待ちを
+          <br />X API の一部有料化に伴い終了したBotもあります。ご了承ください。
         </Box>
         <Box sx={{ width: "90%" }}>
-          <Box>
-            <Typography variant="h6" sx={{ my: 2 }}>
-              じゃんけんBOT
-            </Typography>
-            <Box>
-              Twitterで すずとも とじゃんけんができるBOTです。
-              <br />
-              現在整備中ですので、お待ちください。
-            </Box>
-          </Box>
-          <Box>
-            <Typography variant="h6" sx={{ my: 2 }}>
-              まぁじ占いアンラッキーBOT
-            </Typography>
-            <Box>
-              まぁじ
-              っていう人が毎朝やってる「まぁじ占い」。まぁじ占いはラッキー星座・色しか占わないので、すずともがアンラッキー星座・色を占ってあげています。
-              <br />
-              (ついでに占い情報も収集しています。)
-              <br />
-              現在整備中ですので、お待ちください。
-            </Box>
-          </Box>
           <Box>
             <Typography variant="h6" sx={{ my: 2 }}>
               高専ロボコンInfo-BOT
@@ -60,7 +36,38 @@ const Page: NextPage<Props> = ({ botWorking }) => {
               高専ロボコンが気になった方は
               <Link href="https://official-robocon.com/kosen/">ロボコンHP</Link>
               まで！
-              <Tweet tweetId="1478124008881242113" options={{ lang: "ja" }} />
+              <blockquote className="twitter-tweet" data-lang="ja">
+                <p lang="ja" dir="ltr">
+                  ロボコン2025「Great High Gate」
+                  <br />
+                  <br />
+                  北海道まで　　 27日
+                  <br />
+                  東北まで　　　 41日
+                  <br />
+                  近畿まで　　　 20日
+                  <br />
+                  東海北陸まで　 34日
+                  <br />
+                  九州沖縄まで　 27日
+                  <br />
+                  関東甲信越まで 41日
+                  <br />
+                  中国まで　　　 34日
+                  <br />
+                  四国まで　　　 48日
+                  <br />
+                  <br />
+                  🎖全国まで　 76日
+                  <a href="https://twitter.com/hashtag/%E3%83%AD%E3%83%9C%E3%82%B3%E3%83%B3?src=hash&amp;ref_src=twsrc%5Etfw">
+                    #ロボコン
+                  </a>
+                </p>
+                &mdash; すずとものついったー (@SuzuTomo2001){" "}
+                <a href="https://twitter.com/SuzuTomo2001/status/1962274214930477374?ref_src=twsrc%5Etfw">
+                  2025年8月31日
+                </a>
+              </blockquote>
             </Box>
           </Box>
           <Box>
@@ -74,26 +81,63 @@ const Page: NextPage<Props> = ({ botWorking }) => {
               ナナシスが気になった方は
               <Link href="http://t7s.jp/">Tokyo 7th Sisters 公式HP</Link>
               まで！
-              <Tweet tweetId="1478131558687068160" options={{ lang: "ja" }} />
+              <blockquote className="twitter-tweet" data-lang="ja">
+                <p lang="qme" dir="ltr">
+                  <a href="https://twitter.com/hashtag/%E3%83%8A%E3%83%8A%E3%82%B7%E3%82%B9?src=hash&amp;ref_src=twsrc%5Etfw">
+                    #ナナシス
+                  </a>
+                  <a href="https://twitter.com/hashtag/t7s?src=hash&amp;ref_src=twsrc%5Etfw">
+                    #t7s
+                  </a>
+                  <a href="https://t.co/JRxK29hrB4">
+                    pic.twitter.com/JRxK29hrB4
+                  </a>
+                </p>
+                &mdash; すずとものついったー (@SuzuTomo2001)
+                <a href="https://twitter.com/SuzuTomo2001/status/1962281786848743759?ref_src=twsrc%5Etfw">
+                  2025年8月31日
+                </a>
+              </blockquote>
             </Box>
           </Box>
           <Box>
             <Typography variant="h6" sx={{ my: 2 }}>
-              (くそ)占いBOT
+              じゃんけんBOT（終了）
+            </Typography>
+            <Box>
+              Twitterで すずとも とじゃんけんができるBOTです。
+              <br />X API 有料化に伴い終了しました。
+            </Box>
+          </Box>
+          <Box>
+            <Typography variant="h6" sx={{ my: 2 }}>
+              まぁじ占いアンラッキーBOT（終了）
+            </Typography>
+            <Box>
+              まぁじ
+              っていう人が毎朝やってる「まぁじ占い」。まぁじ占いはラッキー星座・色しか占わないので、すずともがアンラッキー星座・色を占ってあげています。
+              <br />
+              (ついでに占い情報も収集しています。)
+              <br />X API 有料化に伴い終了しました。
+            </Box>
+          </Box>
+          <Box>
+            <Typography variant="h6" sx={{ my: 2 }}>
+              (くそ)占いBOT（終了）
             </Typography>
             <Box>
               Twitterで 占い と送ると運勢とラッキーアイテムが返ってくるBOTです。
               <br />
               @SuzuTomo2001宛に「占い」という文字列を含んだツイートを送信してください。
-              <br />
-              <Mention
-                username="SuzuTomo2001"
-                options={{ text: "占い", size: "large" }}
-              />
+              <br />X API 有料化に伴い終了しました。
             </Box>
           </Box>
         </Box>
       </Box>
+      <Script
+        src="https://platform.twitter.com/widgets.js"
+        strategy="lazyOnload"
+      />
     </>
   );
 };


### PR DESCRIPTION
This pull request updates the `sztm-bot` page to reflect recent changes in Twitter (X) API policies and the status of various bots. It removes dependencies and components related to `react-twitter-widgets`, replaces them with embedded Twitter blockquotes, and updates bot descriptions to indicate which bots have ended due to X API changes.

**Dependency and component cleanup:**

* Removed the `react-twitter-widgets` package from `package.json` and its usage in `pages/sztm-bot.tsx`, switching to embedded Twitter blockquotes for tweet previews. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L40) [[2]](diffhunk://#diff-1ea191ffff138ba6fee0822e220fac79e7e2b39764543dc1ee4c9e658a0aae87R2-L3) [[3]](diffhunk://#diff-1ea191ffff138ba6fee0822e220fac79e7e2b39764543dc1ee4c9e658a0aae87L26-R140)
* Added the Twitter widgets script using the `next/script` component to enable embedded tweet functionality. [[1]](diffhunk://#diff-1ea191ffff138ba6fee0822e220fac79e7e2b39764543dc1ee4c9e658a0aae87R2-L3) [[2]](diffhunk://#diff-1ea191ffff138ba6fee0822e220fac79e7e2b39764543dc1ee4c9e658a0aae87L26-R140)

**Bot status and description updates:**

* Updated bot descriptions to clarify which bots have ended due to X API monetization, and reorganized the order to highlight active bots.
* Replaced previous tweet and mention widgets with blockquote-based tweet embeds for active bots, and removed interactive widgets for discontinued bots.
* Added explanatory notes at the top of the page about bot discontinuations related to X API changes.