### PR TITLE
👍 kosen-calendar を Googleカレンダー埋め込みで表示するように変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
     "": {
       "name": "portfolio",
       "dependencies": {
-        "@aldabil/react-scheduler": "^2.9.5",
         "@emotion/react": "^11.13.3",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.0",
@@ -18,7 +17,6 @@
         "@next/third-parties": "^14.2.15",
         "@octokit/rest": "^22.0.0",
         "clsx": "^2.1.1",
-        "date-fns": "^3.6.0",
         "dayjs": "^1.11.18",
         "dropbox": "^10.34.0",
         "googleapis": "^159.0.0",
@@ -27,7 +25,6 @@
         "microcms-js-sdk": "^3.2.0",
         "next": "14.2.32",
         "nextjs-google-analytics": "^2.3.7",
-        "node-ical": "^0.20.1",
         "opentype.js": "^1.3.4",
         "react": "18.3.1",
         "react-data-grid": "7.0.0-beta.41",
@@ -54,24 +51,6 @@
         "stylelint-config-standard-scss": "^15.0.1",
         "stylelint-order": "^7.0.0",
         "typescript": "^5.6.2"
-      }
-    },
-    "node_modules/@aldabil/react-scheduler": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/@aldabil/react-scheduler/-/react-scheduler-2.9.5.tgz",
-      "integrity": "sha512-PM8D0aFtXIj0XQWvllzwsJuqE1vu34pq33OrcInSMqLAYLgWfRrEh6rYaFJeJ1kAQuzvBGXr0GmVxYut97rIcA==",
-      "peerDependencies": {
-        "@mui/icons-material": ">=5.0.0",
-        "@mui/material": ">=5.0.0",
-        "@mui/x-date-pickers": ">=6.19.0",
-        "date-fns": ">=3.2.0",
-        "react": ">=17.0.0",
-        "rrule": ">=2.8.1"
-      },
-      "peerDependenciesMeta": {
-        "rrule": {
-          "optional": true
-        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5203,17 +5182,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -6045,15 +6013,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dayjs": {
@@ -7352,25 +7311,6 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -7401,6 +7341,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
       "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -9219,25 +9160,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.45",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
-      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
-      "dependencies": {
-        "moment": "^2.29.4"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9392,30 +9314,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/node-ical": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.20.1.tgz",
-      "integrity": "sha512-NrXgzDJd6XcyX9kDMJVA3xYCZmntY7ghA2BOdBeYr3iu8tydHOAb+68jPQhF9V2CRQ0/386X05XhmLzQUN0+Hw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "^1.7.7",
-        "moment-timezone": "^0.5.45",
-        "rrule": "2.8.1",
-        "uuid": "^10.0.0"
-      }
-    },
-    "node_modules/node-ical/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-releases": {
@@ -9971,11 +9869,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "node_modules/pump": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -10463,14 +10356,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rrule": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
-      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "npm run check-types && next lint"
   },
   "dependencies": {
-    "@aldabil/react-scheduler": "^2.9.5",
     "@emotion/react": "^11.13.3",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.0",
@@ -21,7 +20,6 @@
     "@next/third-parties": "^14.2.15",
     "@octokit/rest": "^22.0.0",
     "clsx": "^2.1.1",
-    "date-fns": "^3.6.0",
     "dayjs": "^1.11.18",
     "dropbox": "^10.34.0",
     "googleapis": "^159.0.0",
@@ -30,7 +28,6 @@
     "microcms-js-sdk": "^3.2.0",
     "next": "14.2.32",
     "nextjs-google-analytics": "^2.3.7",
-    "node-ical": "^0.20.1",
     "opentype.js": "^1.3.4",
     "react": "18.3.1",
     "react-data-grid": "7.0.0-beta.41",


### PR DESCRIPTION
This pull request refactors the `kosen-calendar` page to simplify its implementation and remove dependencies related to local calendar parsing and rendering. Instead of fetching and parsing `.ics` files and rendering them with a custom scheduler, the page now embeds a Google Calendar preview via an iframe. Several dependencies are removed from `package.json` as a result.

**Dependencies cleanup:**

* Removed `@aldabil/react-scheduler`, `date-fns`, and `node-ical` from `package.json` since local calendar parsing and custom rendering are no longer used. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L24) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L33)

**Page implementation simplification:**

* Removed all logic related to fetching, parsing, and transforming `.ics` calendar files, including the use of `getStaticProps` and related types. The page no longer uses server-side data fetching or local event processing.
* Replaced the custom calendar rendering (using `@aldabil/react-scheduler`) with a simple Google Calendar embed via an iframe, streamlining the user experience and reducing maintenance overhead. [[1]](diffhunk://#diff-9ba0c74200040ee1cb42dd8c1aa2d0358155651631cdf8cea03cce8e73764b19L112-R49) [[2]](diffhunk://#diff-9ba0c74200040ee1cb42dd8c1aa2d0358155651631cdf8cea03cce8e73764b19L194-R134)

**Code cleanup:**

* Removed unused imports and type definitions related to the previous implementation, resulting in a cleaner and more maintainable codebase. [[1]](diffhunk://#diff-9ba0c74200040ee1cb42dd8c1aa2d0358155651631cdf8cea03cce8e73764b19L1-R2) [[2]](diffhunk://#diff-9ba0c74200040ee1cb42dd8c1aa2d0358155651631cdf8cea03cce8e73764b19L12-L97)